### PR TITLE
ci: backport release pipeline test flight to v4

### DIFF
--- a/.github/workflows/prepare-publish.yml
+++ b/.github/workflows/prepare-publish.yml
@@ -1,0 +1,84 @@
+name: Prepare Publish
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_branch:
+        description: Release target branch.
+        required: true
+        type: string
+      release:
+        description: Bumpp release type.
+        required: true
+        default: next
+        type: choice
+        options:
+          - next
+          - patch
+          - minor
+          - major
+          - prepatch
+          - preminor
+          - premajor
+      version:
+        description: Specify exact version instead of bumpp release type
+        required: false
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.target_branch }}-${{ inputs.version || inputs.release }}
+  cancel-in-progress: false
+
+permissions: {}
+
+env:
+  VITE_TEST_WATCHER_DEBUG: 'false'
+
+jobs:
+  prepare:
+    if: github.repository == 'hi-ogawa/vitest'
+    name: Prepare release PR
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # push the generated prepare branch
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.target_branch }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
+
+      - name: Set node version to 24
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          package-manager-cache: false
+
+      - name: Install
+        run: pnpm install --frozen-lockfile --prefer-offline
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
+
+      # TODO: for now, this step only outputs a compare URL for maintainers to manually create a PR from.
+      # In the future, PR creation can be automated by using a Github App token like .github/workflows/ecosystem-ci-trigger.yml.
+      - name: Prepare release branch
+        id: prepare
+        env:
+          TARGET_BRANCH: ${{ inputs.target_branch }}
+          RELEASE_TYPE: ${{ inputs.release }}
+          RELEASE_VERSION: ${{ inputs.version }}
+          RUN_ID: ${{ github.run_id }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          RELEASE_INPUT="${RELEASE_VERSION:-$RELEASE_TYPE}"
+          PREPARE_BRANCH="prepare-$TARGET_BRANCH-$RELEASE_INPUT-$RUN_ID"
+          git switch -c "$PREPARE_BRANCH"
+          git config user.name "vitest-release-bot"
+          git config user.email "actions@github.com"
+          pnpm run release
+          git push "https://x-access-token:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git" "HEAD:$PREPARE_BRANCH"
+          COMPARE_URL="https://github.com/$GITHUB_REPOSITORY/compare/$TARGET_BRANCH...$PREPARE_BRANCH?expand=1"
+          echo "::notice title=Open release PR::$COMPARE_URL"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,8 +2,9 @@ name: Publish Package
 
 on:
   push:
-    tags:
-      - 'v*'
+    branches:
+      - main
+      - 'v[0-9]*'
 
 permissions:
   contents: write
@@ -14,14 +15,58 @@ env:
   VITE_TEST_WATCHER_DEBUG: 'false'
 
 jobs:
+  # Keep detection outside the Release environment. Environment approval is job-level,
+  # so the publish job is only created after a release commit is detected.
+  detect:
+    if: github.repository == 'hi-ogawa/vitest'
+    name: Detect release commit
+    runs-on: ubuntu-latest
+    outputs:
+      release: ${{ steps.detect.outputs.release }}
+      version: ${{ steps.detect.outputs.version }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Detect release
+        id: detect
+        run: |
+          SUBJECT="$(git log -1 --format=%s)"
+          VERSION="$(jq -r .version package.json)"
+          EXPECTED="chore: release v$VERSION"
+          # use prefix match since commit has PR number trailier.
+          if [[ "$SUBJECT" == "$EXPECTED"* ]]; then
+            echo "release=true" >> "$GITHUB_OUTPUT"
+            echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+            echo "Detected release v$VERSION"
+          else
+            echo "release=false" >> "$GITHUB_OUTPUT"
+            echo "No release commit found at HEAD"
+          fi
+
   publish:
-    if: github.repository == 'vitest-dev/vitest'
+    if: needs.detect.outputs.release == 'true'
+    needs: detect
+    name: Publish Vitest
     runs-on: ubuntu-latest
     environment: Release
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+
+      - name: Check release tag
+        env:
+          VERSION: ${{ needs.detect.outputs.version }}
+        run: |
+          TAG="v$VERSION"
+
+          if git rev-parse --verify --quiet "refs/tags/$TAG"; then
+            echo "Tag $TAG already exists"
+            exit 1
+          fi
 
       - name: Install pnpm
         uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
@@ -41,10 +86,26 @@ jobs:
       - name: Build
         run: pnpm build
 
+      - name: Install good npm
+        run: npm i -g npm@^11.5.2
+
+      - name: Publish to npm (dry run)
+        env:
+          VERSION: ${{ needs.detect.outputs.version }}
+          PUBLISH_DRY_RUN: 'true'
+        run: pnpm run publish-ci "$VERSION"
+
       - name: Publish to npm
-        run: npm i -g npm@^11.5.2 && pnpm run publish-ci ${{ github.ref_name }}
+        env:
+          VERSION: ${{ needs.detect.outputs.version }}
+        run: echo "would publish $VERSION"
+
+      - name: Push release tag
+        env:
+          VERSION: ${{ needs.detect.outputs.version }}
+        run: echo "would push v$VERSION"
 
       - name: Generate Changelog
-        run: npx changelogithub
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.detect.outputs.version }}
+        run: echo "would generate changelog for v$VERSION"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,6 +118,59 @@ These measures help reduce maintenance burden and keep the team's work efficient
 
 > The following section is mostly for maintainers who have commit access, but it's helpful to go through if you intend to make non-trivial contributions to the codebase.
 
+### Release Branches
+
+Public support ranges are documented in [Releases](./docs/releases.md). This section describes how maintainers map those ranges to Git branches for releases and backports. These names refer to branches, not release tags; release tags always include the full version, for example `v4.1.8`.
+
+- `main` is the active development branch for the next release line.
+- `vN` is the latest maintained minor line for non-main major version `N`.
+- `vN.M` is an older minor line for major version `N`, kept when that exact minor still needs releases or backports.
+
+As a hypothetical example, if `v5.1.2` is the latest Vitest release, and the latest releases for older majors are `v4.1.7` and `v3.2.4`, the branch shape can be:
+
+- `main` is the active development branch for `5.1.x`.
+- `v5.0` is an older minor line for Vitest 5.
+- `v4` is the latest maintained minor line for Vitest 4, so it is the `4.1.x` line.
+- `v4.0` is an older minor line for Vitest 4.
+- `v3` is the latest maintained minor line for Vitest 3, so it is the `3.2.x` line.
+- `v3.1` and `v3.0` are older minor lines for Vitest 3.
+
+The `v5` branch does not exist yet. It will be created from the latest v5 minor only after `main` moves on to a newer release line, such as `6.0.0` or often `6.0.0-beta.x`.
+
+For backports, first use the public support policy to decide which version ranges are supported, then map them to branches:
+
+- Changes can land as usual on the `main` branch first.
+- If the fix targets the latest maintained minor of major version `N`, target `vN`. This is the default backport target for a supported non-main major.
+- If the fix also needs an older maintained minor `N.M`, target `vN.M`.
+
+For example, using the hypothetical `v5.1.2` release above, the public support policy covers regular fixes for `5.1.x` and important fixes or security patches for `5.0.x` and `4.1.x`:
+
+- fixes for `5.1.x` target `main`
+- backports to `5.0.x` target `v5.0`
+- backports to `4.1.x` target `v4`
+
+No backport is made to `v3` unless the support policy changes or maintainers decide on an explicit exception.
+
+Backport PR titles should include the target branch in a `[backport to x]` marker, for example `fix: [backport to v5.0] ...` or `fix: [backport to v4] ...`. Branch names never include patch versions.
+
+#### Documentation Branches
+
+The release branches are also linked with the documentation site releases:
+
+- `main` is the source for unreleased documentation at <https://main.vitest.dev/>.
+- `release` points to the latest stable release line used for <https://vitest.dev/>. Release managers update it manually for non-beta releases from `main`; it is not moved for older-line backports.
+- `vN` branches are used for old major documentation sites. For example, <https://v3.vitest.dev/> uses `v3`.
+
+### Release process
+
+Releases — publishing the npm packages, creating the git release tag, and generating the associated GitHub release — are driven by a pull request and carried out by GitHub Actions, not from a maintainer's machine. The release PR holds the version bump, and merging it kicks off the actual publish.
+
+1. **Prepare the release PR.** Run the `Prepare Publish` workflow, setting the `target_branch` input to the branch that matches the [release branch](#release-branches) convention for the release line, then choose the `release` or `version` input to control the version bump. The default input is `release: next`, which bumps the version to the next patch version for stable releases (e.g. `4.1.2 -> 4.1.3`), or the next prerelease version when the current version is already a prerelease (e.g. `4.2.0-beta.2 -> 4.2.0-beta.3`). Use `release: conventional` to derive the bump from the commit history, set `release` to a specific bump type, or pass an exact `version` for pre-releases. To preview the version a given `release` input resolves to, you can run `pnpm release` locally first — it lists the commits since the last release and lets you browse available release types and versions interactively (cancel before confirming so nothing is committed). The workflow pushes the version bump to a branch and prints a compare URL; open that URL to create the release PR.
+
+2. **Review and merge.** Review the version bump, then merge the PR so the `chore: release v*` commit lands on the release branch — that commit is what triggers the Publish step.
+
+3. **Publish.** The release commit starts the `Publish Package` workflow, which pauses for a maintainer to approve the `Release` environment. Once approved, it builds and publishes the packages to npm, pushes the release tag, and generates the GitHub release. Approve when prompted, then confirm npm, the tag, and the GitHub release all look right.
+
 ### Issue Triaging Workflow
 
 ```mermaid

--- a/scripts/publish-ci.ts
+++ b/scripts/publish-ci.ts
@@ -32,12 +32,16 @@ const releaseTag = version.includes('beta')
   : version.includes('alpha')
     ? 'alpha'
     : undefined
+const dryRun = process.env.PUBLISH_DRY_RUN === 'true'
+const dryRunArgs = dryRun ? ['--dry-run'] : []
 
-console.log('Publishing version', version, 'with tag', releaseTag || 'latest')
+console.log(dryRun ? 'Dry-running version' : 'Publishing version', version, 'with tag', releaseTag || 'latest')
 
 if (releaseTag) {
-  await $`pnpm -r publish --access public --no-git-checks --tag ${releaseTag}`
+  await $`pnpm -r publish --access public --no-git-checks --tag ${releaseTag} ${dryRunArgs}`
 }
 else {
-  await $`pnpm -r publish --access public --no-git-checks`
+  // TODO: make stable backport releases use branch-aware npm dist-tags instead of
+  // falling through to `latest`, for example vN -> VN and vN.M -> VN_M.
+  await $`pnpm -r publish --access public --no-git-checks ${dryRunArgs}`
 }

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -1,22 +1,25 @@
-#!/usr/bin/env zx
-
 import { versionBump } from 'bumpp'
 import { glob } from 'tinyglobby'
 
-try {
-  const packages = await glob(['package.json', './packages/*/package.json'], { expandDirectories: false })
+async function main() {
+  const packages = await glob(['package.json', './packages/*/package.json'], {
+    expandDirectories: false,
+  })
 
   console.log('Bumping versions in packages:', packages.join(', '), '\n')
 
+  const release = process.env.RELEASE_VERSION || process.env.RELEASE_TYPE
+
   await versionBump({
     files: packages,
-    commit: true,
-    push: true,
-    tag: true,
+    release,
+    tag: false,
+    push: false,
+    confirm: !release,
   })
+}
 
-  console.log('New release is ready, waiting for conformation at https://github.com/vitest-dev/vitest/actions')
-}
-catch (err) {
-  console.error(err)
-}
+main().catch((error) => {
+  console.error('Error during version bump:', error)
+  process.exit(1)
+})


### PR DESCRIPTION
Smoke testing backport release-pipeline workflow on the fork v4 branch.

Based on https://github.com/hi-ogawa/vitest/pull/6.

<!-- VITEST_AUTOMATED_PR -->