### PR TITLE
(test publish) fix: create release preparation commit

### DIFF
--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -13,6 +13,7 @@ async function main() {
   await versionBump({
     files: packages,
     release,
+    commit: true,
     tag: false,
     push: false,
     confirm: !release,


### PR DESCRIPTION
Ensure the release preparation script creates the version-bump commit before the workflow pushes the prepare branch.

<!-- VITEST_AUTOMATED_PR -->