### PR TITLE
(test publish) fix: inherit publish command output

### DIFF
--- a/scripts/publish-ci.ts
+++ b/scripts/publish-ci.ts
@@ -32,14 +32,15 @@ const releaseTag = version.includes('beta')
     : undefined
 const dryRun = process.env.PUBLISH_DRY_RUN === 'true'
 const dryRunArgs = dryRun ? ['--dry-run'] : []
+const $$ = $({ stdio: 'inherit' })
 
 console.log(dryRun ? 'Dry-running version' : 'Publishing version', version, 'with tag', releaseTag || 'latest')
 
 if (releaseTag) {
-  await $({ stdio: 'inherit' })`pnpm -r publish --access public --no-git-checks --tag ${releaseTag} ${dryRunArgs}`
+  await $$`pnpm -r publish --access public --no-git-checks --tag ${releaseTag} ${dryRunArgs}`
 }
 else {
   // TODO: make stable backport releases use branch-aware npm dist-tags instead of
   // falling through to `latest`, for example vN -> VN and vN.M -> VN_M.
-  await $({ stdio: 'inherit' })`pnpm -r publish --access public --no-git-checks ${dryRunArgs}`
+  await $$`pnpm -r publish --access public --no-git-checks ${dryRunArgs}`
 }

--- a/scripts/publish-ci.ts
+++ b/scripts/publish-ci.ts
@@ -36,10 +36,10 @@ const dryRunArgs = dryRun ? ['--dry-run'] : []
 console.log(dryRun ? 'Dry-running version' : 'Publishing version', version, 'with tag', releaseTag || 'latest')
 
 if (releaseTag) {
-  await $`pnpm -r publish --access public --no-git-checks --tag ${releaseTag} ${dryRunArgs}`.stdio('inherit')
+  await $({ stdio: 'inherit' })`pnpm -r publish --access public --no-git-checks --tag ${releaseTag} ${dryRunArgs}`
 }
 else {
   // TODO: make stable backport releases use branch-aware npm dist-tags instead of
   // falling through to `latest`, for example vN -> VN and vN.M -> VN_M.
-  await $`pnpm -r publish --access public --no-git-checks ${dryRunArgs}`.stdio('inherit')
+  await $({ stdio: 'inherit' })`pnpm -r publish --access public --no-git-checks ${dryRunArgs}`
 }


### PR DESCRIPTION
## Summary

- configure `zx` stdio before spawning the publish subprocess
- make dry-run and publish command output visible in GitHub Actions logs

## Test

- `pnpm exec eslint scripts/publish-ci.ts`
- `git diff --check`

<!-- VITEST_AUTOMATED_PR -->