### PR TITLE
(test publish) fix: show publish command output

### DIFF
--- a/scripts/publish-ci.ts
+++ b/scripts/publish-ci.ts
@@ -1,5 +1,3 @@
-#!/usr/bin/env zx
-
 import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { $ } from 'zx'
@@ -34,14 +32,15 @@ const releaseTag = version.includes('beta')
     : undefined
 const dryRun = process.env.PUBLISH_DRY_RUN === 'true'
 const dryRunArgs = dryRun ? ['--dry-run'] : []
+const $$ = $({ stdio: 'inherit' })
 
 console.log(dryRun ? 'Dry-running version' : 'Publishing version', version, 'with tag', releaseTag || 'latest')
 
 if (releaseTag) {
-  await $`pnpm -r publish --access public --no-git-checks --tag ${releaseTag} ${dryRunArgs}`
+  await $$`pnpm -r publish --access public --no-git-checks --tag ${releaseTag} ${dryRunArgs}`
 }
 else {
   // TODO: make stable backport releases use branch-aware npm dist-tags instead of
   // falling through to `latest`, for example vN -> VN and vN.M -> VN_M.
-  await $`pnpm -r publish --access public --no-git-checks ${dryRunArgs}`
+  await $$`pnpm -r publish --access public --no-git-checks ${dryRunArgs}`
 }

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -13,6 +13,7 @@ async function main() {
   await versionBump({
     files: packages,
     release,
+    commit: true,
     tag: false,
     push: false,
     confirm: !release,


### PR DESCRIPTION
## Summary

- remove the `zx` shebang from `scripts/publish-ci.ts` since it is run through `tsx`
- reuse an inherited-stdio `zx` shell for the publish subprocess so dry-run and publish logs are visible in GitHub Actions

## Test

- `pnpm install --frozen-lockfile`
- `pnpm exec eslint scripts/publish-ci.ts`
- `git diff --check`

<!-- VITEST_AUTOMATED_PR -->