### PR TITLE
test: backport release pipeline to v3

### DIFF
--- a/.github/workflows/prepare-publish.yml
+++ b/.github/workflows/prepare-publish.yml
@@ -1,0 +1,85 @@
+name: Prepare Publish
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_branch:
+        description: Release target branch.
+        required: true
+        default: main
+        type: string
+      release:
+        description: Bumpp release type.
+        required: true
+        default: next
+        type: choice
+        options:
+          - next
+          - patch
+          - minor
+          - major
+          - prepatch
+          - preminor
+          - premajor
+      version:
+        description: Specify exact version instead of bumpp release type
+        required: false
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.target_branch }}-${{ inputs.version || inputs.release }}
+  cancel-in-progress: false
+
+permissions: {}
+
+env:
+  VITE_TEST_WATCHER_DEBUG: 'false'
+
+jobs:
+  prepare:
+    if: github.repository == 'hi-ogawa/vitest'
+    name: Prepare release PR
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # push the generated prepare branch
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.target_branch }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
+
+      - name: Set node version to 24
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          package-manager-cache: false
+
+      - name: Install
+        run: pnpm install --frozen-lockfile --prefer-offline
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
+
+      # TODO: for now, this step only outputs a compare URL for maintainers to manually create a PR from.
+      # In the future, PR creation can be automated by using a Github App token like .github/workflows/ecosystem-ci-trigger.yml.
+      - name: Prepare release branch
+        id: prepare
+        env:
+          TARGET_BRANCH: ${{ inputs.target_branch }}
+          RELEASE_TYPE: ${{ inputs.release }}
+          RELEASE_VERSION: ${{ inputs.version }}
+          RUN_ID: ${{ github.run_id }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          RELEASE_INPUT="${RELEASE_VERSION:-$RELEASE_TYPE}"
+          PREPARE_BRANCH="prepare-$TARGET_BRANCH-$RELEASE_INPUT-$RUN_ID"
+          git switch -c "$PREPARE_BRANCH"
+          git config user.name "vitest-release-bot"
+          git config user.email "actions@github.com"
+          pnpm run release
+          git push "https://x-access-token:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git" "HEAD:$PREPARE_BRANCH"
+          COMPARE_URL="https://github.com/$GITHUB_REPOSITORY/compare/$TARGET_BRANCH...$PREPARE_BRANCH?expand=1"
+          echo "::notice title=Open release PR::$COMPARE_URL"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,8 +2,9 @@ name: Publish Package
 
 on:
   push:
-    tags:
-      - 'v*'
+    branches:
+      - main
+      - 'v[0-9]*'
 
 permissions: {}
 
@@ -12,9 +13,40 @@ env:
   VITE_TEST_WATCHER_DEBUG: 'false'
 
 jobs:
+  # Keep detection outside the Release environment. Environment approval is job-level,
+  # so the publish job is only created after a release commit is detected.
+  detect:
+    if: github.repository == 'hi-ogawa/vitest'
+    name: Detect release commit
+    runs-on: ubuntu-latest
+    outputs:
+      release: ${{ steps.detect.outputs.release }}
+      version: ${{ steps.detect.outputs.version }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Detect release
+        id: detect
+        run: |
+          SUBJECT="$(git log -1 --format=%s)"
+          VERSION="$(jq -r .version package.json)"
+          EXPECTED="chore: release v$VERSION"
+          # use prefix match since commit has PR number trailier.
+          if [[ "$SUBJECT" == "$EXPECTED"* ]]; then
+            echo "release=true" >> "$GITHUB_OUTPUT"
+            echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+            echo "Detected release v$VERSION"
+          else
+            echo "release=false" >> "$GITHUB_OUTPUT"
+            echo "No release commit found at HEAD"
+          fi
+
   publish:
-    # only run on main, don't trigger in forks
-    if: github.repository == 'vitest-dev/vitest'
+    if: needs.detect.outputs.release == 'true'
+    needs: detect
     name: Publish Vitest
     runs-on: ubuntu-latest
     permissions:
@@ -26,6 +58,17 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+
+      - name: Check release tag
+        env:
+          VERSION: ${{ needs.detect.outputs.version }}
+        run: |
+          TAG="v$VERSION"
+
+          if git rev-parse --verify --quiet "refs/tags/$TAG"; then
+            echo "Tag $TAG already exists"
+            exit 1
+          fi
 
       - name: Install pnpm
         uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
@@ -46,10 +89,27 @@ jobs:
       - name: Build
         run: pnpm build
 
+      - name: Install good npm
+        run: npm i -g npm@^11.5.2
+
+      - name: Publish to npm (dry run)
+        env:
+          VERSION: ${{ needs.detect.outputs.version }}
+          PUBLISH_BRANCH: ${{ github.ref_name }}
+          PUBLISH_DRY_RUN: 'true'
+        run: pnpm run publish-ci "$VERSION"
+
       - name: Publish to npm
-        run: npm i -g npm@^11.5.2 && pnpm run publish-ci "${GITHUB_REF_NAME}"
+        env:
+          VERSION: ${{ needs.detect.outputs.version }}
+        run: echo "would publish $VERSION"
+
+      - name: Push release tag
+        env:
+          VERSION: ${{ needs.detect.outputs.version }}
+        run: echo "would push v$VERSION"
 
       - name: Generate Changelog
-        run: npx changelogithub
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.detect.outputs.version }}
+        run: echo "would generate changelog for v$VERSION"

--- a/scripts/publish-ci.ts
+++ b/scripts/publish-ci.ts
@@ -1,43 +1,92 @@
-#!/usr/bin/env zx
-
 import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { $ } from 'zx'
 
-if (process.env.VITEST_GENERATE_UI_TOKEN !== 'true' || process.env.VITE_TEST_WATCHER_DEBUG !== 'false') {
-  throw new Error(`Cannot release Vitest without VITEST_GENERATE_UI_TOKEN=${process.env.VITEST_GENERATE_UI_TOKEN} and VITE_TEST_WATCHER_DEBUG=${process.env.VITE_TEST_WATCHER_DEBUG} environment variable. `)
+// Example:
+// VITEST_GENERATE_UI_TOKEN=true VITE_TEST_WATCHER_DEBUG=false PUBLISH_DRY_RUN=true PUBLISH_BRANCH=v3 pnpm publish-ci 3.2.7
+
+const $$ = $({ stdio: 'inherit' })
+
+async function main() {
+  if (process.env.VITEST_GENERATE_UI_TOKEN !== 'true' || process.env.VITE_TEST_WATCHER_DEBUG !== 'false') {
+    throw new Error(`Cannot release Vitest without VITEST_GENERATE_UI_TOKEN=${process.env.VITEST_GENERATE_UI_TOKEN} and VITE_TEST_WATCHER_DEBUG=${process.env.VITE_TEST_WATCHER_DEBUG} environment variable. `)
+  }
+
+  const version = process.argv[2]
+  if (!version) {
+    throw new Error('Missing argument to specify version')
+  }
+
+  const pkgPath = fileURLToPath(new URL('../package.json', import.meta.url))
+  const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'))
+  if (pkg.version !== version) {
+    throw new Error(
+      `Input version "${version}" does not match package.json version "${pkg.version}"`,
+    )
+  }
+
+  const publishBranch = process.env.PUBLISH_BRANCH
+  if (!publishBranch) {
+    throw new Error('Missing PUBLISH_BRANCH environment variable')
+  }
+  const releaseTag = await getReleaseTag(version, publishBranch)
+
+  const dryRun = process.env.PUBLISH_DRY_RUN === 'true'
+  if (dryRun) {
+    console.log('== DRY RUN ==')
+  }
+  console.log(`Publishing version '${version}' with tag '${releaseTag}'`)
+  await $$`pnpm -r publish --access public --no-git-checks --tag ${releaseTag} --filter="!vite-node" --filter="!@vitest/ws-client" ${dryRun ? ['--dry-run'] : []}`
 }
 
-let version = process.argv[2]
+async function getReleaseTag(version: string, publishBranch: string) {
+  if (version.includes('beta')) {
+    return 'beta'
+  }
+  if (version.includes('alpha')) {
+    return 'alpha'
+  }
 
-if (!version) {
-  throw new Error('No tag specified')
+  // Need to specify tag explicitly for backport version releases
+  // since otherwise `latest` tag would be overwritten.
+  // Note that `main` branch doesn't always mean `latest` tag because of pre-release phase.
+  // Use following mapping to avoid https://docs.npmjs.com/cli/v11/commands/npm-dist-tag#caveats
+  // - v3 branch -> V3 dist tag
+  // - v3.1 branch -> V3.1 dist tag
+
+  const npmView = await $`npm view vitest dist-tags --json`
+  const latestVersion = JSON.parse(npmView.stdout).latest
+  if (isGreaterStableVersion(version, latestVersion)) {
+    return 'latest'
+  }
+
+  return publishBranch.toUpperCase()
 }
 
-if (version.startsWith('v')) {
-  version = version.slice(1)
+function parseStableVersion(version: string) {
+  const match = version.match(/^(\d+)\.(\d+)\.(\d+)$/)
+
+  if (!match) {
+    throw new Error(`Cannot compare non-stable version "${version}"`)
+  }
+
+  return match.slice(1).map(Number)
 }
 
-const pkgPath = fileURLToPath(new URL('../package.json', import.meta.url))
-const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'))
+function isGreaterStableVersion(version: string, latestVersion: string) {
+  const current = parseStableVersion(version)
+  const latest = parseStableVersion(latestVersion)
 
-if (pkg.version !== version) {
-  throw new Error(
-    `Package version from tag "${version}" mismatches with the current version "${pkg.version}"`,
-  )
+  for (let i = 0; i < current.length; i++) {
+    if (current[i] !== latest[i]) {
+      return current[i] > latest[i]
+    }
+  }
+
+  return false
 }
 
-const releaseTag = version.includes('beta')
-  ? 'beta'
-  : version.includes('alpha')
-    ? 'alpha'
-    : undefined
-
-console.log('Publishing version', version, 'with tag', releaseTag || 'latest')
-
-if (releaseTag) {
-  await $`pnpm -r publish --access public --no-git-checks --tag ${releaseTag}`
-}
-else {
-  await $`pnpm -r publish --access public --no-git-checks --tag V3 --filter="!vite-node" --filter="!@vitest/ws-client"`
-}
+main().catch((error) => {
+  console.error('Error during publishing:', error)
+  process.exit(1)
+})

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -1,22 +1,27 @@
-#!/usr/bin/env zx
-
 import { versionBump } from 'bumpp'
 import { glob } from 'tinyglobby'
 
-try {
-  const packages = await glob(['package.json', './packages/*/package.json'], { expandDirectories: false })
+async function main() {
+  const packages = await glob(['package.json', './packages/*/package.json'], {
+    expandDirectories: false,
+  })
 
   console.log('Bumping versions in packages:', packages.join(', '), '\n')
 
+  const release = process.env.RELEASE_VERSION || process.env.RELEASE_TYPE
+
   await versionBump({
     files: packages,
+    release,
     commit: true,
-    push: true,
-    tag: true,
+    tag: false,
+    push: false,
+    printCommits: false,
+    confirm: !release,
   })
+}
 
-  console.log('New release is ready, waiting for conformation at https://github.com/vitest-dev/vitest/actions')
-}
-catch (err) {
-  console.error(err)
-}
+main().catch((error) => {
+  console.error('Error during version bump:', error)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary

- backport fork-safe PR-driven release workflow for v3 test flight
- add prepare-publish workflow and branch-triggered publish detection
- update release/publish scripts for release commits, dry-run publish, visible publish logs, and v3 dist-tag handling

## Test

- `pnpm install --frozen-lockfile`
- `pnpm exec eslint scripts/publish-ci.ts scripts/release.ts`
- `git diff --check`

<!-- VITEST_AUTOMATED_PR -->